### PR TITLE
Make any post-processor inherit from IImageProcessor only.

### DIFF
--- a/XR_APILAYER_NOVENDOR_toolkit/factories.h
+++ b/XR_APILAYER_NOVENDOR_toolkit/factories.h
@@ -76,20 +76,17 @@ namespace toolkit {
                                                    ID3D12Resource* texture,
                                                    const std::optional<std::string>& debugName);
 
-        std::shared_ptr<IUpscaler> CreateNISUpscaler(std::shared_ptr<toolkit::config::IConfigManager> configManager,
-                                                     std::shared_ptr<IDevice> graphicsDevice,
-                                                     uint32_t outputWidth,
-                                                     uint32_t outputHeight);
+        std::shared_ptr<IImageProcessor>
+        CreateNISUpscaler(std::shared_ptr<toolkit::config::IConfigManager> configManager,
+                          std::shared_ptr<IDevice> graphicsDevice,
+                          uint32_t outputWidth,
+                          uint32_t outputHeight);
 
-        std::shared_ptr<IUpscaler> CreateFSRUpscaler(std::shared_ptr<toolkit::config::IConfigManager> configManager,
-                                                     std::shared_ptr<IDevice> graphicsDevice,
-                                                     uint32_t outputWidth,
-                                                     uint32_t outputHeight);
-
-        bool IsDeviceSupportingFP16(std::shared_ptr<IDevice> device);
-
-        GpuArchitecture GetGpuArchitecture(UINT VendorId);
-        GpuArchitecture GetGpuArchitecture(std::shared_ptr<IDevice> device);
+        std::shared_ptr<IImageProcessor>
+        CreateFSRUpscaler(std::shared_ptr<toolkit::config::IConfigManager> configManager,
+                          std::shared_ptr<IDevice> graphicsDevice,
+                          uint32_t outputWidth,
+                          uint32_t outputHeight);
 
         std::shared_ptr<IImageProcessor>
         CreateImageProcessor(std::shared_ptr<toolkit::config::IConfigManager> configManager,
@@ -103,6 +100,11 @@ namespace toolkit {
                                  std::shared_ptr<IDevice> graphicsDevice,
                                  uint32_t targetWidth,
                                  uint32_t targetHeight);
+
+        bool IsDeviceSupportingFP16(std::shared_ptr<IDevice> device);
+
+        GpuArchitecture GetGpuArchitecture(UINT VendorId);
+        GpuArchitecture GetGpuArchitecture(std::shared_ptr<IDevice> device);
 
     } // namespace graphics
 

--- a/XR_APILAYER_NOVENDOR_toolkit/fsr.cpp
+++ b/XR_APILAYER_NOVENDOR_toolkit/fsr.cpp
@@ -47,7 +47,7 @@ namespace {
         uint32_t Const4[4];
     };
 
-    class FSRUpscaler : public IUpscaler {
+    class FSRUpscaler : public IImageProcessor {
       public:
         FSRUpscaler(std::shared_ptr<IConfigManager> configManager,
                     std::shared_ptr<IDevice> graphicsDevice,
@@ -69,7 +69,7 @@ namespace {
             }
         }
 
-        void upscale(std::shared_ptr<ITexture> input, std::shared_ptr<ITexture> output, int32_t slice = -1) override {
+        void process(std::shared_ptr<ITexture> input, std::shared_ptr<ITexture> output, int32_t slice = -1) override {
             if (!m_intermediary) {
                 const auto& infos = output->getInfo();
                 initializeIntermediary(infos.width, infos.height, 0 /* infos.format */);
@@ -203,10 +203,10 @@ namespace {
 
 namespace toolkit::graphics {
 
-    std::shared_ptr<IUpscaler> CreateFSRUpscaler(std::shared_ptr<IConfigManager> configManager,
-                                                 std::shared_ptr<IDevice> graphicsDevice,
-                                                 uint32_t outputWidth,
-                                                 uint32_t outputHeight) {
+    std::shared_ptr<IImageProcessor> CreateFSRUpscaler(std::shared_ptr<IConfigManager> configManager,
+                                                       std::shared_ptr<IDevice> graphicsDevice,
+                                                       uint32_t outputWidth,
+                                                       uint32_t outputHeight) {
         return std::make_shared<FSRUpscaler>(configManager, graphicsDevice, outputWidth, outputHeight);
     }
 

--- a/XR_APILAYER_NOVENDOR_toolkit/interfaces.h
+++ b/XR_APILAYER_NOVENDOR_toolkit/interfaces.h
@@ -568,16 +568,6 @@ namespace toolkit {
             }
         };
 
-        // A texture upscaler (such as NIS).
-        struct IUpscaler {
-            virtual ~IUpscaler() = default;
-
-            virtual void update() = 0;
-            virtual void upscale(std::shared_ptr<ITexture> input,
-                                 std::shared_ptr<ITexture> output,
-                                 int32_t slice = -1) = 0;
-        };
-
         // A texture post-processor.
         struct IImageProcessor {
             virtual ~IImageProcessor() = default;

--- a/XR_APILAYER_NOVENDOR_toolkit/layer.cpp
+++ b/XR_APILAYER_NOVENDOR_toolkit/layer.cpp
@@ -1415,7 +1415,7 @@ namespace {
                                 m_stats.upscalerGpuTimeUs += swapchainImages.upscalerGpuTimer[gpuTimerIndex]->query();
                                 swapchainImages.upscalerGpuTimer[gpuTimerIndex]->start();
 
-                                m_upscaler->upscale(swapchainImages.chain[lastImage],
+                                m_upscaler->process(swapchainImages.chain[lastImage],
                                                     swapchainImages.chain[nextImage],
                                                     useVPRT ? eye : -1);
                                 swapchainImages.upscalerGpuTimer[gpuTimerIndex]->stop();
@@ -1612,13 +1612,13 @@ namespace {
         std::shared_ptr<graphics::IDevice> m_graphicsDevice;
         std::map<XrSwapchain, SwapchainState> m_swapchains;
 
-        std::shared_ptr<graphics::IUpscaler> m_upscaler;
+        std::shared_ptr<graphics::IImageProcessor> m_preProcessor;
+        std::shared_ptr<graphics::IImageProcessor> m_postProcessor;
+        std::shared_ptr<graphics::IImageProcessor> m_upscaler;
         config::ScalingType m_upscaleMode{config::ScalingType::None};
         uint32_t m_upscalingFactor{100};
         float m_mipMapBiasForUpscaling{0.f};
 
-        std::shared_ptr<graphics::IImageProcessor> m_preProcessor;
-        std::shared_ptr<graphics::IImageProcessor> m_postProcessor;
 
         std::shared_ptr<graphics::IFrameAnalyzer> m_frameAnalyzer;
         std::shared_ptr<graphics::IVariableRateShader> m_variableRateShader;

--- a/XR_APILAYER_NOVENDOR_toolkit/nis.cpp
+++ b/XR_APILAYER_NOVENDOR_toolkit/nis.cpp
@@ -42,7 +42,7 @@ namespace {
     using namespace toolkit::log;
     using namespace toolkit::utilities;
 
-    class NISUpscaler : public IUpscaler {
+    class NISUpscaler : public IImageProcessor {
       public:
         NISUpscaler(std::shared_ptr<IConfigManager> configManager,
                     std::shared_ptr<IDevice> graphicsDevice,
@@ -64,7 +64,7 @@ namespace {
             }
         }
 
-        void upscale(std::shared_ptr<ITexture> input, std::shared_ptr<ITexture> output, int32_t slice = -1) override {
+        void process(std::shared_ptr<ITexture> input, std::shared_ptr<ITexture> output, int32_t slice = -1) override {
             m_device->setShader(!input->isArray() ? m_shader : m_shaderVPRT);
             m_device->setShaderInput(0, m_configBuffer);
             m_device->setShaderInput(0, input, slice);
@@ -230,10 +230,10 @@ namespace {
 
 namespace toolkit::graphics {
 
-    std::shared_ptr<IUpscaler> CreateNISUpscaler(std::shared_ptr<IConfigManager> configManager,
-                                                 std::shared_ptr<IDevice> graphicsDevice,
-                                                 uint32_t outputWidth,
-                                                 uint32_t outputHeight) {
+    std::shared_ptr<IImageProcessor> CreateNISUpscaler(std::shared_ptr<IConfigManager> configManager,
+                                                       std::shared_ptr<IDevice> graphicsDevice,
+                                                       uint32_t outputWidth,
+                                                       uint32_t outputHeight) {
         return std::make_shared<NISUpscaler>(configManager, graphicsDevice, outputWidth, outputHeight);
     }
 


### PR DESCRIPTION
No need to have a special IUpscaler root and in using only IImageProcessor we can manage all post-processors in a single container in the future (graph, tree, vector etc...)