### PR TITLE
- Simplify setRenderTargets() arguments passing depth buffer as a sha…

### DIFF
--- a/XR_APILAYER_NOVENDOR_toolkit/interfaces.h
+++ b/XR_APILAYER_NOVENDOR_toolkit/interfaces.h
@@ -501,7 +501,7 @@ namespace toolkit {
             virtual void setRenderTargets(size_t numRenderTargets,
                                           std::shared_ptr<ITexture>* renderTargets,
                                           int32_t* renderSlices = nullptr,
-                                          std::shared_ptr<ITexture>* depthBuffer = nullptr,
+                                          std::shared_ptr<ITexture> depthBuffer = nullptr,
                                           int32_t depthSlice = -1) = 0;
             virtual void unsetRenderTargets() = 0;
 
@@ -745,8 +745,7 @@ namespace toolkit {
             virtual void updateGesturesState(const input::GesturesState& state) = 0;
             virtual void updateEyeGazeState(const input::EyeGazeState& state) = 0;
 
-            virtual void
-            setViewProjectionCenters(XrVector2f left, XrVector2f right) = 0;
+            virtual void setViewProjectionCenters(XrVector2f left, XrVector2f right) = 0;
         };
 
     } // namespace menu

--- a/XR_APILAYER_NOVENDOR_toolkit/layer.cpp
+++ b/XR_APILAYER_NOVENDOR_toolkit/layer.cpp
@@ -1783,7 +1783,7 @@ namespace {
                         m_graphicsDevice->setRenderTargets(1,
                                                            &textureForOverlay[eye],
                                                            useVPRT ? reinterpret_cast<int32_t*>(&eye) : nullptr,
-                                                           &depthForOverlay[eye],
+                                                           depthForOverlay[eye],
                                                            useVPRT ? eye : -1);
 
                         m_graphicsDevice->setViewProjection(viewsForOverlay[eye]);


### PR DESCRIPTION
…red_ptr instead of shared_ptr*.

- Correct bug with setRenderTargets() introduced in previous D3D11 and D3D21 refactoring (dereferencing nullptr).
- Correct bug with D3D11 dispatchShader() not clearing the right number (m_currentShaderHighestSRV insted of m_currentShaderHighestUAV).
- Replace getXXXXViewInternal() with makeXXXXViewInternal() to remove assignement within the functions and make the invariants clearer.
- Various constness added throughout where appropriate.