### PR TITLE
Support for quad layer pass through.

### DIFF
--- a/XR_APILAYER_NOVENDOR_toolkit/d3d11.cpp
+++ b/XR_APILAYER_NOVENDOR_toolkit/d3d11.cpp
@@ -1470,6 +1470,10 @@ namespace {
             m_copyTextureEvent = event;
         }
 
+        void copyTexture(std::shared_ptr<ITexture> destination, std::shared_ptr<ITexture> source) override {
+            m_context->CopyResource(destination->getAs<D3D11>(), source->getAs<D3D11>());
+        }
+
         uint32_t getBufferAlignmentConstraint() const override {
             return 16;
         }

--- a/XR_APILAYER_NOVENDOR_toolkit/d3d12.cpp
+++ b/XR_APILAYER_NOVENDOR_toolkit/d3d12.cpp
@@ -1778,6 +1778,10 @@ namespace {
             m_copyTextureEvent = event;
         }
 
+        void copyTexture(std::shared_ptr<ITexture> destination, std::shared_ptr<ITexture> source) override {
+            m_context->CopyResource(destination->getAs<D3D12>(), source->getAs<D3D12>());
+        }
+
         uint32_t getBufferAlignmentConstraint() const override {
             return D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT;
         }

--- a/XR_APILAYER_NOVENDOR_toolkit/interfaces.h
+++ b/XR_APILAYER_NOVENDOR_toolkit/interfaces.h
@@ -616,6 +616,8 @@ namespace toolkit {
                                                         int /* destinationSlice */)>;
             virtual void registerCopyTextureEvent(CopyTextureEvent event) = 0;
 
+            virtual void copyTexture(std::shared_ptr<ITexture> destination, std::shared_ptr<ITexture> source) = 0;
+
             virtual void shutdown() = 0;
 
             virtual uint32_t getBufferAlignmentConstraint() const = 0;

--- a/XR_APILAYER_NOVENDOR_toolkit/layer.cpp
+++ b/XR_APILAYER_NOVENDOR_toolkit/layer.cpp
@@ -1934,17 +1934,9 @@ namespace {
                     auto& swapchainState = swapchainIt->second;
                     auto& swapchainImages = swapchainState.images[swapchainState.acquiredImageIndex];
 
-                    uint32_t nextImage = 0;
-                    uint32_t lastImage = 0;
-
-                    for (size_t i = 0; i < std::size(m_imageProcessors); i++) {
-                        if (m_imageProcessors[i]) {
-                            nextImage++;
-                            m_graphicsDevice->copyTexture(swapchainImages.chain[nextImage],
-                                                          swapchainImages.chain[lastImage]);
-                            lastImage++;
-                        }
-                    }
+                    size_t swapChainSize = std::size(swapchainImages.chain);
+                    if (swapChainSize > 1)
+                        m_graphicsDevice->copyTexture(swapchainImages.chain[swapChainSize - 1], swapchainImages.chain[0]);
 
                     correctedLayers.push_back(chainFrameEndInfo.layers[i]);
                 } else {


### PR DESCRIPTION
Copy quad layers through the swap chain to match projection layer image processing steps. Works on AMS2 and Dirt Rally 2.

Closes #278 