### PR TITLE
Quad layer copy fix

### DIFF
--- a/XR_APILAYER_NOVENDOR_toolkit/d3d11.cpp
+++ b/XR_APILAYER_NOVENDOR_toolkit/d3d11.cpp
@@ -514,7 +514,8 @@ namespace {
         }
 
         void copyTo(std::shared_ptr<ITexture> destination) const override {
-            m_device->getContextAs<D3D11>()->CopyResource(destination->getAs<D3D11>(), m_texture.Get());
+            m_device->getContextAs<D3D11>()->CopySubresourceRegion(
+                destination->getAs<D3D11>(), 0, 0, 0, 0, m_texture.Get(), 0, nullptr);
         }
 
         void saveToFile(const std::filesystem::path& path) const override {

--- a/XR_APILAYER_NOVENDOR_toolkit/d3d12.cpp
+++ b/XR_APILAYER_NOVENDOR_toolkit/d3d12.cpp
@@ -463,7 +463,10 @@ namespace {
         }
 
         void copyTo(std::shared_ptr<ITexture> destination) const override {
-            m_device->getContextAs<D3D12>()->CopyResource(destination->getAs<D3D12>(), m_texture.Get());
+            D3D12_TEXTURE_COPY_LOCATION destLoc{destination->getAs<D3D12>(), D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX, 0};
+            D3D12_TEXTURE_COPY_LOCATION srcLoc{m_texture.Get(), D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX, 0};
+            m_device->getContextAs<D3D12>()->CopyTextureRegion(&destLoc, 0, 0, 0, &srcLoc, nullptr);
+
         }
 
         void saveToFile(const std::filesystem::path& path) const override {


### PR DESCRIPTION
Change to use CopySubresourceRegion (DX11) and CopyTextureRegion (DX12) to copy quad layer textures directly. Solves issue when menus / guis don't appear when using upscaling (FSR/NIS).