### PR TITLE
Workaround for Fallout 4 VR decal issue

### DIFF
--- a/XR_APILAYER_NOVENDOR_toolkit/interfaces.h
+++ b/XR_APILAYER_NOVENDOR_toolkit/interfaces.h
@@ -178,6 +178,7 @@ namespace toolkit {
         const std::string SettingEyeDebugWithController = "eye_controller_debug";
         const std::string SettingResolutionOverride = "override_resolution";
         const std::string SettingResolutionWidth = "resolution_width";
+        const std::string SettingNoInterEyeRotation = "no_inter_eye_rotation";
 
         enum class OffOnType { Off = 0, On, MaxValue };
         enum class NoYesType { No = 0, Yes, MaxValue };

--- a/XR_APILAYER_NOVENDOR_toolkit/layer.cpp
+++ b/XR_APILAYER_NOVENDOR_toolkit/layer.cpp
@@ -1366,6 +1366,14 @@ namespace {
                 m_posesForFrame[0].pose = views[0].pose;
                 m_posesForFrame[1].pose = views[1].pose;
 
+                // No inter eye rotation workaround
+                if (m_configManager->getValue(config::SettingNoInterEyeRotation)) {
+                    views[0].pose.orientation.w = views[1].pose.orientation.w;
+                    views[0].pose.orientation.x = views[1].pose.orientation.x;
+                    views[0].pose.orientation.y = views[1].pose.orientation.y;
+                    views[0].pose.orientation.z = views[1].pose.orientation.z;
+                }
+
                 // Override the canting angle if requested.
                 const int cantOverride = m_configManager->getValue("canting");
                 if (cantOverride != 0) {

--- a/XR_APILAYER_NOVENDOR_toolkit/menu.cpp
+++ b/XR_APILAYER_NOVENDOR_toolkit/menu.cpp
@@ -1415,6 +1415,16 @@ namespace {
                  }});
             m_menuEntries.back().acceleration = 10;
 
+            m_menuEntries.push_back({MenuIndent::OptionIndent,
+                                     "No inter eye rotation workaround",
+                                     MenuEntryType::Choice,
+                                     SettingNoInterEyeRotation,
+                                     0,
+                                     MenuEntry::LastVal<NoYesType>(),
+                                     MenuEntry::FmtEnum<NoYesType>});
+
+
+
             // Must be kept last.
             systemTab.finalize();
         }


### PR DESCRIPTION
Simple workaround for Fallout 4 VR decal issue. Probably not 100% mathematically correct (I just assign the right eye rotation to the left eye) but seems to do the trick well enough