### PR TITLE
Support Bethesda Games in OpenComposite

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ Logo and icons designed by RPthreenine.
 
 User Experience designed by Andrew Lilley (FarFutureFox).
 
-Additional contributions by James Lacey (Jabbah) and Bernhard Berger.
+Additional contributions by James Lacey (Jabbah), Bernhard Berger, and Erik Uri.
 
 Many thanks to the https://forums.flightsimulator.com/ community for the testing and feedback!

--- a/XR_APILAYER_MBUCCHIA_toolkit/layer.cpp
+++ b/XR_APILAYER_MBUCCHIA_toolkit/layer.cpp
@@ -275,9 +275,9 @@ namespace {
             // not being advertised. However for certain apps using double-wide rendering, we can still enable the
             // feature, based on the list of apps below.
             m_overrideFoveatedRenderingCapability =
-                (m_applicationName == "OpenComposite_AC2-Win64-Shipping" ||
-                 m_applicationName == "OpenComposite_SkyrimVR" ||
-                 m_applicationName == "OpenComposite_Fallout4VR");                                     
+                m_applicationName == "OpenComposite_AC2-Win64-Shipping" ||
+                m_applicationName == "OpenComposite_SkyrimVR" ||
+                m_applicationName == "OpenComposite_Fallout4VR";                                     
 
             // Dump the OpenXR runtime information to help debugging customer issues.
             XrInstanceProperties instanceProperties = {XR_TYPE_INSTANCE_PROPERTIES, nullptr};

--- a/XR_APILAYER_MBUCCHIA_toolkit/layer.cpp
+++ b/XR_APILAYER_MBUCCHIA_toolkit/layer.cpp
@@ -275,7 +275,9 @@ namespace {
             // not being advertised. However for certain apps using double-wide rendering, we can still enable the
             // feature, based on the list of apps below.
             m_overrideFoveatedRenderingCapability =
-                m_isOpenComposite && m_applicationName == "OpenComposite_AC2-Win64-Shipping";
+                (m_applicationName == "OpenComposite_AC2-Win64-Shipping" ||
+                 m_applicationName == "OpenComposite_SkyrimVR" ||
+                 m_applicationName == "OpenComposite_Fallout4VR");                                     
 
             // Dump the OpenXR runtime information to help debugging customer issues.
             XrInstanceProperties instanceProperties = {XR_TYPE_INSTANCE_PROPERTIES, nullptr};

--- a/XR_APILAYER_MBUCCHIA_toolkit/layer.cpp
+++ b/XR_APILAYER_MBUCCHIA_toolkit/layer.cpp
@@ -496,6 +496,10 @@ namespace {
 
                 m_supportMotionReprojectionLock = isWMR;
 
+                // Fix Fallout 4 / OpenComposite Decal Issue for WMR
+                m_overrideParallelProjection =
+                    m_applicationName == "OpenComposite_Fallout4VR" && isWMR;
+
                 // Workaround: the Vive runtime does not seem to properly convert timestamps. We disable any feature
                 // depending on timestamps conversion.
                 m_hasPerformanceCounterKHR = !isVive;
@@ -1718,6 +1722,14 @@ namespace {
 
                 m_posesForFrame[0].pose = views[0].pose;
                 m_posesForFrame[1].pose = views[1].pose;
+
+                // Fix Fallout 4 / OpenComposite Decal Issue for WMR
+                if (m_overrideParallelProjection) {
+                    views[0].pose.orientation.w = views[1].pose.orientation.w;
+                    views[0].pose.orientation.x = views[1].pose.orientation.x;
+                    views[0].pose.orientation.y = views[1].pose.orientation.y;
+                    views[0].pose.orientation.z = views[1].pose.orientation.z;
+                }
 
                 // Override the canting angle if requested.
                 const int cantOverride = m_configManager->getValue("canting");
@@ -3402,6 +3414,7 @@ namespace {
         bool m_hasPimaxEyeTracker{false};
         bool m_isFrameThrottlingPossible{true};
         bool m_overrideFoveatedRenderingCapability{false};
+        bool m_overrideParallelProjection{false};
 
         std::mutex m_frameLock;
         XrTime m_waitedFrameTime;


### PR DESCRIPTION
This consists of two changes.

- OpenXR-Toolkit now recognizes that Skyrim VR & Fallout 4 VR use double wide rendering, and sets `m_overrideFoveatedRenderingCapability` to true with these titles to allow eye tracking to be enabled in OpenComposite.
- `m_overrideParallelProjection` is set to true when the current title is Fallout 4 in WMR/OpenComposite, and then applies slight changes to correct the depth of decals on surfaces in this title.