### PR TITLE
Update Ultraleap links and instructions

### DIFF
--- a/hand-tracking.md
+++ b/hand-tracking.md
@@ -28,13 +28,11 @@ See [Supported headsets / Hand tracking feature](index#hand-tracking-feature).
 
 ## Using with Ultraleap (including Pimax and Varjo headsets)
 
-1. Download and install the [Leap Motion tracking software](https://developer.leapmotion.com/tracking-software-download).
+1. Download and install the [Ultraleap tracking software](https://developer.leapmotion.com/tracking-software-download) which includes their OpenXR API layer.
 
-2. Use the included Visualizer app to confirm that the Leap Motion Controller is properly setup and functional.
+2. Use the included Visualizer app to confirm that the Ultraleap tracking device is properly setup and functional, and that **OpenXR Support** is enabled in settings (it is enabled by default).
 
-3. Download and install the [Ultraleap OpenXR Hand Tracking API Layer](https://github.com/ultraleap/OpenXRHandTracking/releases).
-
-4. With your game running, open the menu (Ctrl+F2), then navigate to the **Input** tab. Under **Controller emulation**, select either **Both** to use both hands, or **Left**/**Right** to use only one hand. Restart the VR session for the hand tracking to begin.
+3. With your game running, open the menu (Ctrl+F2), then navigate to the **Input** tab. Under **Controller emulation**, select either **Both** to use both hands, or **Left**/**Right** to use only one hand. Restart the VR session for the hand tracking to begin.
 
 ![Enable hand tracking](site/hand-tracking.png)<br>
 *Enable hand tracking in OpenXR Toolkit*

--- a/how-does-it-work.md
+++ b/how-does-it-work.md
@@ -44,7 +44,7 @@ These two APIs are not compatible. An application that is written to support VR 
 
 Certain OpenXR runtimes offer VR controller to hand tracking API translation: for example the Windows Mixed Reality runtime does (and this is why if you look at the list of OpenXR extension in the _Developer Tools for Windows Mixed Reality_, you will spot the `XR_EXT_hand_tracking` extension). This means that even though the platform does not support hand tracking, applications designed with hand tracking support only will still work with the VR controllers. There are limitations, as the VR controller cannot simulate all 26 hand joints.
 
-Certain vendors, such as Ultraleap, have developed their own [OpenXR API layer](https://github.com/ultraleap/OpenXRHandTracking) to offer the `XR_EXT_hand_tracking` extension for hand tracking with their products. **However, this support only works with application that are designed with hand tracking support**. For applications that only support the VR controller input APIs, the Ultraleap support will not help.
+Certain vendors, such as Ultraleap, have developed their own [OpenXR API layer](https://developer.leapmotion.com/tracking-software-download) to offer the `XR_EXT_hand_tracking` extension for hand tracking with their products. **However, this support only works with application that are designed with hand tracking support**. For applications that only support the VR controller input APIs, the Ultraleap support will not help.
 
 Enters the OpenXR Toolkit. The toolkit's API layer sits between the application **and the Ultraleap API layer**, performing translation of the `XR_EXT_hand_tracking` APIs into VR controller inputs. Technically, the OpenXR runtime is not involved in this process.
 


### PR DESCRIPTION
This PR updates Ultraleap links to the new locations now the OpenXR API layer is included as part of the normal Ultraleap downloads. It also updates the instructions to account for the fact there is now only a single installation step.