### PR TITLE
VRS (Eye Tracked, Foveated Rendering) Support for Bethesda Games w/ DLSS

### DIFF
--- a/XR_APILAYER_MBUCCHIA_toolkit/d3d12.cpp
+++ b/XR_APILAYER_MBUCCHIA_toolkit/d3d12.cpp
@@ -1655,6 +1655,12 @@ namespace {
             m_currentMesh.reset();
         }
 
+        void onSetViewports(ID3D11DeviceContext* context,
+                            UINT* numViewports,
+                            const D3D11_VIEWPORT* pViewports) {
+            return; // do nothing
+        }
+
         XrExtent2Di getViewportSize() const override {
             return m_currentDrawRenderTargetViewport.extent;
         }
@@ -1949,6 +1955,15 @@ namespace {
         void registerUnsetRenderTargetEvent(UnsetRenderTargetEvent event) override {
             m_unsetRenderTargetEvent = event;
         }
+
+        void registerSetViewportsEvent(SetViewportsEvent event) override {
+            m_setViewportsEvent = event;
+        }
+
+        void registerUnsetViewportsEvent(UnsetViewportsEvent event) override {
+            m_unsetViewportsEvent = event;
+        }
+
 
         void registerCopyTextureEvent(CopyTextureEvent event) override {
             m_copyTextureEvent = event;
@@ -2338,6 +2353,8 @@ namespace {
 
         SetRenderTargetEvent m_setRenderTargetEvent;
         UnsetRenderTargetEvent m_unsetRenderTargetEvent;
+        SetViewportsEvent m_setViewportsEvent;
+        UnsetViewportsEvent m_unsetViewportsEvent;
         CopyTextureEvent m_copyTextureEvent;
         std::atomic<bool> m_blockEvents{false};
 

--- a/XR_APILAYER_MBUCCHIA_toolkit/interfaces.h
+++ b/XR_APILAYER_MBUCCHIA_toolkit/interfaces.h
@@ -653,6 +653,11 @@ namespace toolkit {
             virtual void registerSetRenderTargetEvent(SetRenderTargetEvent event) = 0;
             using UnsetRenderTargetEvent = std::function<void(std::shared_ptr<IContext>)>;
             virtual void registerUnsetRenderTargetEvent(UnsetRenderTargetEvent event) = 0;
+            using SetViewportsEvent =
+                std::function<void(std::shared_ptr<IContext>, std::shared_ptr<D3D11_VIEWPORT> viewports)>;
+            virtual void registerSetViewportsEvent(SetViewportsEvent event) = 0;
+            using UnsetViewportsEvent = std::function<void(std::shared_ptr<IContext>)>;
+            virtual void registerUnsetViewportsEvent(UnsetRenderTargetEvent event) = 0;
             using CopyTextureEvent = std::function<void(std::shared_ptr<IContext> /* context */,
                                                         std::shared_ptr<ITexture> /* source */,
                                                         std::shared_ptr<ITexture> /* destination */,
@@ -740,6 +745,10 @@ namespace toolkit {
                                            std::shared_ptr<ITexture> renderTarget,
                                            std::optional<utilities::Eye> eyeHint) = 0;
             virtual void onUnsetRenderTarget(std::shared_ptr<graphics::IContext> context) = 0;
+
+            virtual bool onSetViewports(std::shared_ptr<IContext> context,
+                                              std::shared_ptr<D3D11_VIEWPORT> viewports) = 0;
+            virtual void onUnsetViewports(std::shared_ptr<IContext> context) = 0;
 
             virtual void updateGazeLocation(XrVector2f gaze, utilities::Eye eye) = 0;
             virtual void setViewProjectionCenters(XrVector2f left, XrVector2f right) = 0;


### PR DESCRIPTION
Currently, OpenXR Toolkit applies Variable Rate (Foveated) Shading on the drawable instead of the Viewport. It is now a common pattern for games to render into a viewport and upscale into a drawable using AI upscales such as DLSS. 

This PR fixes the issue where you render the game, upscale it, and then apply VRS to a static image out of the upscaler. We also have to account for the eye pose being in a different position for the viewport vs the drawable. DLSS does a good job at hiding the blocky nature of VRS and hides the resolution banding.